### PR TITLE
Bug suggestion migration

### DIFF
--- a/docs/database/mStats.md
+++ b/docs/database/mStats.md
@@ -14,7 +14,9 @@ This document is the base of all documents in the `allTime`, `daily` and `hourly
     guildsJoined: number;
     guildsLeft: number;
     guildsTotal: number;
-    errors: number;
+    errorsTotal: number;
+    bugs: number; // total bugs reported
+    botSuggestions: number; // total bot suggestions made
     commandTotal: number; // total used
     commands: {
         // key is command name, usage data

--- a/docs/database/mStats.md
+++ b/docs/database/mStats.md
@@ -4,7 +4,7 @@ This file contains the definitions for all documents in all collections in the m
 
 ## Base Document
 
-This document is the base of all documents in nearly all collections. Each collection adds other stuff to it, but always the same base document.
+This document is the base of all documents in the `allTime`, `daily` and `hourly` collections. Each collection adds other stuff to it, but always the same base document.
 
 ```Typescript
 {
@@ -130,7 +130,6 @@ one document for each hour of one day with the base document as base
 
 ## errors Collection Document
 
-THIS COLLECTION DOES NOT USE THE BASE DOCUMENT.
 One document for each error (same errors count as one error)
 
 ```Typescript
@@ -140,5 +139,29 @@ One document for each error (same errors count as one error)
     md5: hash; // md5 hash to check if the error is the same
     count: number; // how many times it was thrown
     error: any; // error object
+}
+```
+
+## bugs Collection Document
+
+One document for each bug.
+
+```Typescript
+{
+    guild?: string; // guild ID where it was reported (optional)
+    user: string; // user ID which reported it
+    bug: string; // bug description
+}
+```
+
+## suggestions Collection Document
+
+One document for each suggestion.
+
+```Typescript
+{
+    guild?: string; // guild ID where it was suggested (optional)
+    user: string; // user ID which suggested it
+    suggestion: string; // suggestion description
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,6 +1328,11 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pjson": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/pjson/-/pjson-1.0.9.tgz",
+      "integrity": "sha512-4hRJH3YzkUpOlShRzhyxAmThSNnAaIlWZCAb27hd0pVUAXNUAHAO7XZbsPPvsCYwBFEScTmCCL6DGE8NyZ8BdQ=="
+    },
     "prism-media": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "express": "^4.17.1",
         "googleapis": "^44.0.0",
         "mongoose": "^5.7.1",
+        "pjson": "^1.0.9",
         "request": "^2.88.0",
         "xml2js": "^0.4.22"
     },

--- a/src/commands/Misc/botsuggest.ts
+++ b/src/commands/Misc/botsuggest.ts
@@ -4,9 +4,7 @@ import { permLevels } from '../../utils/permissions';
 import { Bot } from '../..';
 import { sendError } from '../../utils/messages';
 import { permToString, durationToString } from '../../utils/parsers';
-import request = require('request');
 import { durations, getDurationDiff } from '../../utils/time';
-import { suggestionForm } from '../../bot-config.json';
 
 var command: commandInterface = {
     name: 'botsuggest',

--- a/src/commands/Misc/botsuggest.ts
+++ b/src/commands/Misc/botsuggest.ts
@@ -69,18 +69,8 @@ var command: commandInterface = {
                 return false;
             }
 
-            // send suggestion to google form
-            let form = {};
-            form['entry.' + suggestionForm.serverID] = (!dm ? message.guild.id : undefined);
-            form['entry.' + suggestionForm.serverName] = (!dm ? message.guild.name : undefined);
-            form['entry.' + suggestionForm.userID] = message.author.id;
-            form['entry.' + suggestionForm.userName] = message.author.username;
-            form['entry.' + suggestionForm.messageID] = message.id;
-            form['entry.' + suggestionForm.channelID] = message.channel.id;
-            form['entry.' + suggestionForm.suggestion] = args;
-            request.post('https://docs.google.com/forms/d/e/1FAIpQLSee3V4--MxBJqPjoDgfUIw2u22NG-4GBlT92Bbj10-R1ScuHA/formResponse', {
-                form: form
-            });
+            // log suggestion
+            Bot.mStats.logBotSuggestion(message, args);
             
             // send confirmation message
             Bot.mStats.logResponseTime(command.name, requestTime);

--- a/src/commands/Misc/bug.ts
+++ b/src/commands/Misc/bug.ts
@@ -4,9 +4,7 @@ import { permLevels } from '../../utils/permissions';
 import { Bot } from '../..';
 import { sendError } from '../../utils/messages';
 import { permToString, durationToString } from '../../utils/parsers';
-import request = require('request');
 import { durations, getDurationDiff } from '../../utils/time';
-import { bugForm } from '../../bot-config.json';
 
 var command: commandInterface = {
     name: 'bug',

--- a/src/commands/Misc/bug.ts
+++ b/src/commands/Misc/bug.ts
@@ -69,18 +69,8 @@ var command: commandInterface = {
                 return false;
             }
 
-            // send suggestion to google form
-            let form = {};
-            form['entry.' + bugForm.serverID] = (!dm ? message.guild.id : undefined);
-            form['entry.' + bugForm.serverName] = (!dm ? message.guild.name : undefined);
-            form['entry.' + bugForm.userID] = message.author.id;
-            form['entry.' + bugForm.userName] = message.author.username;
-            form['entry.' + bugForm.messageID] = message.id;
-            form['entry.' + bugForm.channelID] = message.channel.id;
-            form['entry.' + bugForm.bug] = args;
-            request.post('https://docs.google.com/forms/d/e/1FAIpQLScWsqLDncKzqSgmZuFhuwenqexzmKSr0K_B4GSOgoF6fEBcMA/formResponse', {
-                form: form
-            });
+            // log bug
+            await Bot.mStats.logBug(message, args);
 
             // send confirmation message
             Bot.mStats.logResponseTime(command.name, requestTime);

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -4,7 +4,7 @@ import { permLevels } from '../utils/permissions';
 import { Bot } from '..';
 import { sendError } from '../utils/messages';
 import { permToString } from '../utils/parsers';
-import { version } from '../bot-config.json';
+import { version } from 'pjson';
 
 var command: commandInterface = { name: undefined, path: undefined, dm: undefined, permLevel: undefined, togglable: undefined, shortHelp: undefined, embedHelp: undefined, run: undefined };
 
@@ -25,12 +25,23 @@ command.run = async (message: Message, args: string, permLevel: number, dm: bool
                 },
                 "author": {
                     "name": "BulletBot",
-                    "icon_url": Bot.client.user.displayAvatarURL
+                    "icon_url": Bot.client.user.displayAvatarURL,
+                    "url": "https://github.com/CodeBullet-Community/BulletBot"
                 },
                 "fields": [
                     {
+                        "name": "Github Repo:",
+                        "value": "[CodeBullet-Community/BulletBot](https://github.com/CodeBullet-Community/BulletBot)",
+                        "inline": true
+                    },
+                    {
+                        "name": "Discord Server:",
+                        "value": "[BulletBot](https://discord.gg/74py7yd)",
+                        "inline": true
+                    },
+                    {
                         "name": "My Creators:",
-                        "value": "Codec#1167 (Planning/Coding)\nBark Ranger#0985(Main Hosting)\nanAlius#7139 (Coding)\nLucavon#2154 (Dev Hosting)\nMontori#4707 (Coding)\n2 others",
+                        "value": "Codec#1167\nBark Ranger#0985\nanAlius#7139\nMontori#4707\n2 others",
                         "inline": true
                     },
                     {

--- a/src/database/mStats.ts
+++ b/src/database/mStats.ts
@@ -620,16 +620,17 @@ export class MStats {
      * logs a bug and saves it to the database
      *
      * @param {Message} message message that reported the bug
+     * @param {string} bug description of the bug
      * @returns
      * @memberof MStats
      */
-    logBug(message: Message) {
+    logBug(message: Message, bug:string) {
         if (!this.hourly) return;
         this.hourly.doc.bugs ++;
         return new this.bugs({
             user: message.author.id,
             guild: message.guild ? message.guild.id : undefined,
-            bug: message.content
+            bug: bug
         }).save();
     }
 
@@ -637,16 +638,17 @@ export class MStats {
      * logs a suggestion and saves it to the database
      *
      * @param {Message} message message that suggested the suggestion
+     * @param {suggestion} suggestion suggestion description
      * @returns
      * @memberof MStats
      */
-    logBotSuggestion(message: Message) {
+    logBotSuggestion(message: Message, suggestion: string) {
         if (!this.hourly) return;
         this.hourly.doc.botSuggestions ++;
         return new this.suggestions({
             user: message.author.id,
             guild: message.guild ? message.guild.id : undefined,
-            suggestion: message.content
+            suggestion: suggestion
         }).save();
     }
 

--- a/src/database/schemas.ts
+++ b/src/database/schemas.ts
@@ -909,7 +909,7 @@ export interface botSuggestionDoc extends mongoose.Document, botSuggestionObject
 export const botSuggestionSchema = new mongoose.Schema({
     guild: { type: String, required: false },
     user: String,
-    bug: String,
+    suggestion: String,
 });
 
 // youtube webhook

--- a/src/database/schemas.ts
+++ b/src/database/schemas.ts
@@ -622,6 +622,8 @@ export interface mStatsObject {
     guildsLeft: number;
     guildsTotal: number;
     errorsTotal: number;
+    bugs: number; // total bugs reported
+    botSuggestions: number; // total bot suggestions made
     commandTotal: number; // total used
     commands: {
         // key is command name, usage data
@@ -708,6 +710,8 @@ export function createEmptyMStatsObject(): mStatsObject {
         guildsLeft: 0,
         guildsTotal: 0,
         errorsTotal: 0,
+        bugs: 0,
+        botSuggestions: 0,
         commandTotal: 0,
         commands: {},
         filters: {},
@@ -774,6 +778,8 @@ const mStatsSchemaStruc = {
     guildsLeft: Number,
     guildsTotal: Number,
     errorsTotal: Number,
+    bugs: Number,
+    botSuggestions: Number,
     commandTotal: Number,
     commands: mongoose.Schema.Types.Mixed,
     filters: mongoose.Schema.Types.Mixed,
@@ -878,7 +884,33 @@ export const errorSchema = new mongoose.Schema({
     md5: String,
     count: Number,
     error: mongoose.Schema.Types.Mixed
-})
+});
+
+// bug
+export interface bugObject {
+    guild?: string; // guild ID where it was reported (optional)
+    user: string; // user ID which reported it
+    bug: string; // bug description
+}
+export interface bugDoc extends mongoose.Document, bugObject { }
+export const bugSchema = new mongoose.Schema({
+    guild: { type: String, required: false },
+    user: String,
+    bug: String,
+});
+
+// suggestion
+export interface botSuggestionObject {
+    guild?: string; // guild ID where it was suggested (optional)
+    user: string; // user ID which suggested it
+    suggestion: string; // suggestion description
+}
+export interface botSuggestionDoc extends mongoose.Document, botSuggestionObject { }
+export const botSuggestionSchema = new mongoose.Schema({
+    guild: { type: String, required: false },
+    user: String,
+    bug: String,
+});
 
 // youtube webhook
 export interface webhookObject {
@@ -898,7 +930,7 @@ export const webhookSchema = new mongoose.Schema({
 // global settings
 export interface globalSettingsObject {
     prefix: string;
-    presence: PresenceData;    
+    presence: PresenceData;
     embedColors: {
         default: number;
         help: number;


### PR DESCRIPTION
- migrated bugs and suggestions to the database (from [this issue](../issues/14))
- mStats now logs how many bugs and suggestion were reported/made
- updated `info` command because the bot was made opensource
- `info` command now uses the version number from `package.json` (I had to add the `pjson` because tsc wouldn't allow me to import a file outside `src`) (from [this issue](../issues/36))
