### PR TITLE
Fixing a major oversight in the master installer

### DIFF
--- a/installers/Linux_Universal/bb-start-modes/run-in-background-autorestart.sh
+++ b/installers/Linux_Universal/bb-start-modes/run-in-background-autorestart.sh
@@ -68,7 +68,7 @@ fi
 
 # Waits in order to give bulletbot.service enough time to (re)start
 while ((timer > 0)); do
-    echo -en "$timer seconds left \r"
+    echo -en "\r$timer seconds left "
     sleep 1
     ((timer-=1))
 done

--- a/installers/Linux_Universal/bb-start-modes/run-in-background.sh
+++ b/installers/Linux_Universal/bb-start-modes/run-in-background.sh
@@ -64,7 +64,7 @@ fi
 
 # Waits in order to give bulletbot.service enough time to (re)start
 while ((timer > 0)); do
-    echo -en "$timer seconds left \r"
+    echo -en "\r$timer seconds left "
     sleep 1
     ((timer-=1))
 done

--- a/installers/Linux_Universal/setup/bot-config-setup.sh
+++ b/installers/Linux_Universal/setup/bot-config-setup.sh
@@ -222,7 +222,7 @@ if [[ $bullet_status = "active" ]]; then
     # Waits in order to give bulletbot.service enough time to (re)start
     echo "Waiting 20 seconds for bulletbot.service to start..."
     while ((timer > 0)); do
-        echo -en "$timer seconds left \r"
+        echo -en "\r$timer seconds left "
         sleep 1
         ((timer-=1))
     done


### PR DESCRIPTION
This is to fix a major oversight I made. I forgot to implement a way for the master installer to download BulletBot. All it did was check the operating system and figure out whether the installer and BulletBot were compatible with the system. But this pull request contains code that fixes that. (Apologies for the bad grammar)