### PR TITLE
Non members now can be banned with `?!ban`

### DIFF
--- a/src/commands/Moderation/ban.ts
+++ b/src/commands/Moderation/ban.ts
@@ -37,29 +37,29 @@ var command: commandInterface = {
             let argsArray = args.split(' ').filter(x => x.length != 0); // split arguments string by spaces
 
             let user = await stringToUser(argsArray[argIndex]);
-            if (!user) { // check if it found the specified member
-                message.channel.send('Couldn\'t find specified member');
+            if (!user) { // check if it found the specified user
+                message.channel.send('Couldn\'t find specified user');
                 Bot.mStats.logMessageSend();
                 return false;
             }
-            if (user.id == message.author.id) { // check if the requester is the same member
+            if (user.id == message.author.id) { // check if the requester is the same user
                 message.channel.send('You can\'t ban yourself');
                 Bot.mStats.logMessageSend();
                 return false;
             }
-            if (user.id == Bot.client.user.id) { // check if the member is the bot
+            if (user.id == Bot.client.user.id) { // check if the user is the bot
                 message.channel.send('Don\'t ban me :frowning:');
                 Bot.mStats.logMessageSend();
                 return false;
             }
-            if (!await message.guild.me.hasPermission("BAN_MEMBERS")) { // check if the bot has the permissions to ban members
+            if (!await message.guild.me.hasPermission("BAN_MEMBERS")) { // check if the bot has the permissions to ban users
                 message.channel.send("I do not have the permissions to do that");
                 Bot.mStats.logMessageSend();
                 return false;
             }
             argIndex++;
 
-            // parse time to ban member
+            // parse time to ban user
             let time = await stringToDuration(argsArray[argIndex]);
             let stringTime = time ? durationToString(time) : 'forever';
 
@@ -70,11 +70,11 @@ var command: commandInterface = {
             let caseObject = await Bot.caseLogger.logBan(message.guild, user, message.member, reason, time ? time : undefined);
             // incase a time was set, make a pActions unban task
             if (time) Bot.pActions.addBan(message.guild.id, user.id, message.createdTimestamp + time, caseObject.caseID, message.createdTimestamp);
-            // dm to member that they has been banned
+            // dm to user that they has been banned
             try {
                 await user.send(`You were banned in **${message.guild.name}** for ${stringTime} ${reason ? 'because of following reason:\n' + reason : ''}`);
             } catch { }
-            // ban member
+            // ban user
             message.guild.ban(user, { reason: reason, days: 7 });
 
             // send confirmation message

--- a/src/commands/Moderation/ban.ts
+++ b/src/commands/Moderation/ban.ts
@@ -3,7 +3,7 @@ import { commandInterface } from '../../commands';
 import { permLevels, getPermLevel } from '../../utils/permissions';
 import { Bot } from '../..';
 import { sendError } from '../../utils/messages';
-import { permToString, durationToString, stringToMember, stringToDuration } from '../../utils/parsers';
+import { permToString, durationToString, stringToMember, stringToDuration, stringToUser } from '../../utils/parsers';
 import { durations } from '../../utils/time';
 
 var command: commandInterface = {
@@ -36,24 +36,19 @@ var command: commandInterface = {
             let argIndex = 0;
             let argsArray = args.split(' ').filter(x => x.length != 0); // split arguments string by spaces
 
-            let member = await stringToMember(message.guild, argsArray[argIndex], false, false, false);
-            if (!member) { // check if it found the specified member
+            let user = await stringToUser(argsArray[argIndex]);
+            if (!user) { // check if it found the specified member
                 message.channel.send('Couldn\'t find specified member');
                 Bot.mStats.logMessageSend();
                 return false;
             }
-            if (member.user.id == message.author.id) { // check if the requester is the same member
+            if (user.id == message.author.id) { // check if the requester is the same member
                 message.channel.send('You can\'t ban yourself');
                 Bot.mStats.logMessageSend();
                 return false;
             }
-            if (member.user.id == Bot.client.user.id) { // check if the member is the bot
+            if (user.id == Bot.client.user.id) { // check if the member is the bot
                 message.channel.send('Don\'t ban me :frowning:');
-                Bot.mStats.logMessageSend();
-                return false;
-            }
-            if (await getPermLevel(member) >= permLevels.mod) { // check if member is mod or higher
-                message.channel.send('You can\'t ban that member');
                 Bot.mStats.logMessageSend();
                 return false;
             }
@@ -72,17 +67,19 @@ var command: commandInterface = {
             let reason = args.slice(args.indexOf(argsArray[time ? 1 : 0]) + argsArray[time ? 1 : 0].length).trim();
 
             // make a case
-            let caseObject = await Bot.caseLogger.logBan(message.guild, member, message.member, reason, time ? time : undefined);
+            let caseObject = await Bot.caseLogger.logBan(message.guild, user, message.member, reason, time ? time : undefined);
             // incase a time was set, make a pActions unban task
-            if (time) Bot.pActions.addBan(message.guild.id, member.user.id, message.createdTimestamp + time, caseObject.caseID, message.createdTimestamp);
+            if (time) Bot.pActions.addBan(message.guild.id, user.id, message.createdTimestamp + time, caseObject.caseID, message.createdTimestamp);
             // dm to member that they has been banned
-            await member.send(`You were banned in **${message.guild.name}** for ${stringTime} ${reason ? 'because of following reason:\n' + reason : ''}`);
+            try {
+                await user.send(`You were banned in **${message.guild.name}** for ${stringTime} ${reason ? 'because of following reason:\n' + reason : ''}`);
+            } catch { }
             // ban member
-            member.ban({ reason: reason, days: 7 });
+            message.guild.ban(user, { reason: reason, days: 7 });
 
             // send confirmation message
             Bot.mStats.logResponseTime(command.name, requestTime);
-            message.channel.send(`:white_check_mark: **${member.user.tag} has been banned for ${stringTime}${reason ? ", " + reason : ''}**`);
+            message.channel.send(`:white_check_mark: **${user.tag} has been banned for ${stringTime}${reason ? ", " + reason : ''}**`);
             Bot.mStats.logCommandUsage(command.name);
             Bot.mStats.logMessageSend();
             return true;

--- a/src/database/caseLogger.ts
+++ b/src/database/caseLogger.ts
@@ -66,14 +66,14 @@ export class CaseLogger {
     /**
      * Logs a ban into the database and sends an case embed if case channel if provided
      * @param {Guild} guild where the member was banned from
-     * @param {GuildMember} member member that was banned
+     * @param {User} user member that was banned
      * @param {GuildMember} mod mod that banned the member
      * @param {string} reason the reason why the member was banned (optional)
      * @param {number} duration duration of the ban (optional)
      */
-    async logBan(guild: Guild, member: GuildMember, mod: GuildMember, reason?: string, duration?: number) {
+    async logBan(guild: Guild, user: User, mod: GuildMember, reason?: string, duration?: number) {
         let color = Bot.database.settingsDB.cache.embedColors.negative;
-        return await this.logCase(guild, member.user, mod, caseActions.ban, color, reason, duration);
+        return await this.logCase(guild, user, mod, caseActions.ban, color, reason, duration);
     }
 
     /**

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -124,9 +124,13 @@ export async function stringToMember(guild: Guild, text: string, byUsername = tr
  * @param {string} text Text to extract id from
  * @returns User
  */
-export function stringToUser(text: string) {
+export async function stringToUser(text: string) {
     text = extractString(text, /<@!?(\d*)>/) || text;
-    return Bot.client.fetchUser(text);
+    try {
+        return await Bot.client.fetchUser(text);
+    } catch{
+        return undefined;
+    }
 }
 
 /**

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -26,6 +26,12 @@ function stringSimilarity(s1: string, s2: string) {
     return (longerLength - editDistance(longer, shorter)) / parseFloat(longerLength.toString());
 }
 
+function extractString(str: string, regex: RegExp) {
+    let result = regex.exec(str);
+    if (result?.length < 2) return undefined;
+    return result[1];
+}
+
 /**
  * helper function for stringSimilarity
  *
@@ -79,27 +85,7 @@ function editDistance(s1: string, s2: string) {
  * @returns
  */
 export async function stringToMember(guild: Guild, text: string, byUsername = true, byNickname = true, bySimilar: boolean = true) {
-    // extract id form mention
-    if (/<@(\d*)>/g.test(text)) {
-        var result = /<@(\d*)>/g.exec(text);
-        if (result != null) {
-            text = result[1];
-        }
-    }
-    // extract id form mention of a user with a nickname
-    if (/<@!(\d*)>/g.test(text)) {
-        var result = /<@!(\d*)>/g.exec(text);
-        if (result != null) {
-            text = result[1];
-        }
-    }
-    // extract the name from "example#1234"
-    if (/([^#@:]{2,32})#\d{4}/g.test(text)) {
-        var result = /([^#@:]{2,32})#\d{4}/g.exec(text);
-        if (result != null) {
-            text = result[1];
-        }
-    }
+    text = extractString(text, /<@!?(\d*)>/) || extractString(text, /([^#@:]{2,32})#\d{4}/) || text;
     guild = await guild.fetchMembers()
 
     // by id
@@ -121,6 +107,18 @@ export async function stringToMember(guild: Guild, text: string, byUsername = tr
         }
     }
     return member;
+}
+
+/**
+ * Extracts the id from a string and the fetches the User
+ *
+ * @export
+ * @param {string} text Text to extract id from
+ * @returns User
+ */
+export function stringToUser(text: string) {
+    text = extractString(text, /<@!?(\d*)>/) || text;
+    return Bot.client.fetchUser(text);
 }
 
 /**
@@ -150,13 +148,7 @@ export function stringToRole(guild: Guild, text: string, byName = true, bySimila
         return '@everyone';
     }
 
-    // extract id from role mention
-    if (/<@&(\d*)>/g.test(text)) {
-        var result = /<@&(\d*)>/g.exec(text);
-        if (result != null) {
-            text = result[1];
-        }
-    }
+    text = extractString(text, /<@&(\d*)>/) || text;
 
     // by id
     var role = guild.roles.get(text);
@@ -191,13 +183,8 @@ export function stringToRole(guild: Guild, text: string, byName = true, bySimila
  */
 export function stringToChannel(guild: Guild, text: string, byName = true, bySimilar = true) {
     if (!guild) return null;
-    // extract id from channel mention
-    if (/<#(\d*)>/g.test(text)) {
-        var result = /<#(\d*)>/g.exec(text);
-        if (result != null) {
-            text = result[1];
-        }
-    }
+    text = extractString(text, /<#(\d*)>/) || text;
+
     let channel = guild.channels.get(text);
     if (!channel && byName) channel = guild.channels.find(x => x.name == text);
     if (!channel && bySimilar) {

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -26,10 +26,18 @@ function stringSimilarity(s1: string, s2: string) {
     return (longerLength - editDistance(longer, shorter)) / parseFloat(longerLength.toString());
 }
 
+/**
+ * Executes a RegExp on a string and returns last result of first search if successful
+ *
+ * @param {string} str String to search in
+ * @param {RegExp} regex RegExp to search with
+ * @returns
+ */
 function extractString(str: string, regex: RegExp) {
     let result = regex.exec(str);
-    if (result?.length < 2) return undefined;
-    return result[1];
+    if (!result)
+        return undefined;
+    return result[result.length - 1];
 }
 
 /**


### PR DESCRIPTION
This PR addresses a very frustrating issue with the `?!ban` command. The issue was that previously only members were bannable and non-members weren't.
Though the fix does do its job it's not intended as a permanent fix. The command system will be revised soon so putting effort into fixing this properly is unreasonable.